### PR TITLE
Version 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+release.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file, formatted v
 
 ## [1.1.1] = 2018-04-04
 ### Fixed
-- Internal "prime the pump" method now includes all supported post types
+- Internal "prime the pump" method now includes all supported post types. Can be used with [this plugin](https://github.com/billerickson/Shared-Counts-Prime-Cache) to view the status of the cache and mass update posts
 - Improved compatibility with Genesis theme framework
 
 ## [1.1.0] = 2018-03-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file, formatted via [this recommendation](http://keepachangelog.com/).
 
-## [1.1.2] = ?
+## [1.2.0] = 2018-05-23
+### Added
+- Support for [Pinterest Image](https://github.com/billerickson/Shared-Counts-Pinterest-Image) add-on plugin
+
 ### Fixed
 - "Hide empty counts" checkbox now works correctly
+- Pinterest "Pin it" JS no longer modifies our pinterest button, see #34
 - Metabox is now always visible, allowing you to disable share buttons even if not collecting counts, see #33
 
 ## [1.1.1] = 2018-04-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file, formatted via [this recommendation](http://keepachangelog.com/).
 
+## [1.1.2] = ?
+### Fixed
+- "Hide empty counts" checkbox now works correctly
+
 ## [1.1.1] = 2018-04-04
 ### Fixed
 - Internal "prime the pump" method now includes all supported post types. Can be used with [this plugin](https://github.com/billerickson/Shared-Counts-Prime-Cache) to view the status of the cache and mass update posts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, formatted v
 ## [1.1.2] = ?
 ### Fixed
 - "Hide empty counts" checkbox now works correctly
+- Metabox is now always visible, allowing you to disable share buttons even if not collecting counts, see #33
 
 ## [1.1.1] = 2018-04-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file, formatted via [this recommendation](http://keepachangelog.com/).
 
-## [1.1.1] = ?
+## [1.1.1] = 2018-04-04
 ### Fixed
 - Internal "prime the pump" method now includes all supported post types
+- Improved compatibility with Genesis theme framework
 
 ## [1.1.0] = 2018-03-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file, formatted via [this recommendation](http://keepachangelog.com/).
 
+## [1.1.1] = ?
+### Fixed
+- Internal "prime the pump" method now includes all supported post types
+
 ## [1.1.0] = 2018-03-21
 ### Added
 - Yummly share count support/tracking.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Additionally, Shared Counts was built to be developer friendly! We provide very 
 
 * denotes button/service does not support share count tracking.
 
+### Add On Plugins
+- [Shared Counts - Pinterest Image](https://github.com/billerickson/Shared-Counts-Pinterest-Image) - Upload a separate image for Pinterest sharing
+- [Shared Counts - Cache Status](https://github.com/billerickson/Shared-Counts-Cache-Status) - Build and check the status of the Shared Counts cache
+
+
 ## Style Options ##
 
 #### Fancy

--- a/README.md
+++ b/README.md
@@ -23,13 +23,11 @@ Additionally, Shared Counts was built to be developer friendly! We provide very 
 ### Included Services
 - Facebook
 - Pinterest
-- LinkedIn
+- Yummly
 - Twitter (using the third-party NewShareCounts.com API)
 - StumbleUpon
 - Email sharing (with reCAPTCHA support to prevent abuse)
 - Share count totals
-
-
 
 ## Style Options ##
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Tags:** sharing, share buttons, social buttons, share counts, social, facebook, linkedin, pinterest, stumbleupon, twitter  
 **Requires at least:** 4.6  
 **Tested up to:** 4.9  
-**Stable tag:** 1.0.0  
+**Stable tag:** 1.1.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Additionally, Shared Counts was built to be developer friendly! We provide very 
 2. Activate plugin.
 3. Go to Settings > Shared Counts to configure.
 
-We recommend you sign up for a free account at [SharedCounts.com](https://sharedcounts.com), which lets you receive share counts from all services (except Twitter) with a single API query. Alternatively, you can select "Native" as the count source and select which services you'd like to query. If you select all 5 native service queries, then you will have 5 separate API queries every time share counts are updated.
+We recommend you sign up for a free account at [SharedCount.com](https://sharedcount.com), which lets you receive share counts from all services (except Twitter) with a single API query. Alternatively, you can select "Native" as the count source and select which services you'd like to query. If you select all 5 native service queries, then you will have 5 separate API queries every time share counts are updated.
 
 If you would like to include Twitter share counts, you can sign up for a free account at [NewShareCounts.com](https://newsharecounts.com).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Tags:** sharing, share buttons, social buttons, share counts, social, facebook, linkedin, pinterest, stumbleupon, twitter  
 **Requires at least:** 4.6  
 **Tested up to:** 4.9  
-**Stable tag:** 1.1.1  
+**Stable tag:** 1.2.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,7 +14,7 @@ Shared Counts adds social sharing buttons that look great and keep your site loa
 
 We provide a one-click option to retrieve both HTTP and HTTPS share counts, ensuring you don't lose your share counts when upgrading your website to HTTPS.
 
-**GDPR Compliant:** Unlike other social sharing tools, this plugin does not use cookies, tracking scripts, or store any user data. 
+**GDPR Compliant:** Unlike other social sharing tools, this plugin does not use cookies, tracking scripts, or store any user data.
 
 We include many styling options, and you can automatically insert the buttons before and/or after the post content. You can also use the `[shared_counts]` shortcode to insert them inside the content.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Shared Counts was created with site performance in mind, even at large scale. It
 
 Additionally, Shared Counts was built to be developer friendly! We provide very liberal usage of hooks and filters. Everything is customizable and the possibilities are near limitless. Unlike other plugins all data (counts) are stored and cached in post_meta which makes it easy to access for extending (e.g. fetch top 10 most shared posts on your site).
 
-### Included Services
+### Included Buttons
 - Facebook
 - Pinterest
 - Yummly
@@ -28,6 +28,11 @@ Additionally, Shared Counts was built to be developer friendly! We provide very 
 - StumbleUpon
 - Email sharing (with reCAPTCHA support to prevent abuse)
 - Share count totals
+- Print*
+- LinkedIn*
+- Google+*
+
+* denotes button/service does not support share count tracking.
 
 ## Style Options ##
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Shared Counts adds social sharing buttons that look great and keep your site loa
 
 We provide a one-click option to retrieve both HTTP and HTTPS share counts, ensuring you don't lose your share counts when upgrading your website to HTTPS.
 
+**GDPR Compliant:** Unlike other social sharing tools, this plugin does not use cookies, tracking scripts, or store any user data. 
+
 We include many styling options, and you can automatically insert the buttons before and/or after the post content. You can also use the `[shared_counts]` shortcode to insert them inside the content.
 
 Shared Counts was created with site performance in mind, even at large scale. It is used on several large websites that get tens of millions of page views each month. Our unique and creative caching methods have a minimal affect on site overhead. Leveraging the SharedCount.com API, we can retrieve (almost) all share counts in a single request.

--- a/includes/class-shared-counts-core.php
+++ b/includes/class-shared-counts-core.php
@@ -832,8 +832,11 @@ class Shared_Counts_Core {
 	 */
 	public function prime_the_pump( $count = 100, $interval = 20, $messages = false ) {
 
+		$options = shared_counts()->admin->options();
+
 		$current = new WP_Query( array(
 			'fields'         => 'ids',
+			'post_type'      => $options['post_type'],
 			'posts_per_page' => $count,
 			'meta_query'     => array(
 				array(

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -472,7 +472,7 @@ class Shared_Counts_Front {
 			} else {
 				$link['url']   = esc_url( get_permalink( $id ) );
 				$link['title'] = wp_strip_all_tags( get_the_title( $id ) );
-				$link['img']   = apply_filters( 'shared_counts_single_image', wp_get_attachment_image_url( get_post_thumbnail_id(), 'full' ), $id );
+				$link['img']   = apply_filters( 'shared_counts_single_image', wp_get_attachment_image_url( get_post_thumbnail_id(), 'full' ), $id, $link );
 			}
 			$link['url']   = apply_filters( 'shared_counts_link_url', $link['url'] );
 			$link['count'] = shared_counts()->core->count( $id, $type, false, $round );

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -460,19 +460,21 @@ class Shared_Counts_Front {
 			$link          = array();
 			$link['type']  = $type;
 			$link['class'] = '';
+			$link['img']   = apply_filters( 'shared_counts_default_image', '', $id, $link );
 
 			if ( 'site' === $id ) {
 				$link['url']   = esc_url( home_url() );
 				$link['title'] = wp_strip_all_tags( get_bloginfo( 'name' ) );
-				$link['img']   = apply_filters( 'shared_counts_default_image', '', $id );
 			} elseif ( 0 === strpos( $id, 'http' ) ) {
 				$link['url']   = esc_url( $id );
 				$link['title'] = '';
-				$link['img']   = apply_filters( 'shared_counts_default_image', '', $id );
 			} else {
 				$link['url']   = esc_url( get_permalink( $id ) );
 				$link['title'] = wp_strip_all_tags( get_the_title( $id ) );
-				$link['img']   = apply_filters( 'shared_counts_single_image', wp_get_attachment_image_url( get_post_thumbnail_id(), 'full' ), $id, $link );
+				if( has_post_thumbnail( $id ) ) {
+					$link['img'] = wp_get_attachment_image_url( get_post_thumbnail_id( $id ), 'full' );
+				}
+				$link['img'] = apply_filters( 'shared_counts_single_image', $link['img'], $id, $link );
 			}
 			$link['url']   = apply_filters( 'shared_counts_link_url', $link['url'] );
 			$link['count'] = shared_counts()->core->count( $id, $type, false, $round );

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -577,6 +577,9 @@ class Shared_Counts_Front {
 			$link_class = ! empty( $link['class'] ) ? implode( ' ', array_map( 'sanitize_html_class' , explode( ' ', $link['class'] ) ) ) : '';
 			$target     = ! empty( $link['target'] ) ? ' target="' . esc_attr( $link['target'] ) . '" ' : '';
 			$rel        = ! empty( $link['rel'] ) ? ' rel="' . esc_attr( $link['rel'] ) . '" ' : '';
+			if( 'pinterest' == $type )
+				$rel .= ' data-pin-custom="true"';
+
 			$attr_title = ! empty( $link['attr_title'] ) ? ' title="' . esc_attr( $link['attr_title'] ) . '" ' : '';
 			$show_count = true;
 			$elements   = array();

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -592,7 +592,7 @@ class Shared_Counts_Front {
 			}
 
 			// Determine if we should show the count.
-			if ( 'false' === $show_empty && 0 === $link['count'] ) {
+			if ( 'false' === $show_empty && 0 == $link['count'] ) {
 				$show_count = false;
 			}
 			if ( '1' === $options['total_only'] && 'included_total' !== $type ) {

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -53,7 +53,7 @@ class Shared_Counts_Front {
 	public function theme_location() {
 
 		// Genesis Hooks.
-		if ( 'genesis' === get_template_directory() ) {
+		if ( 'genesis' === get_template() ) {
 
 			$locations = array(
 				'before' => array(

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -577,9 +577,6 @@ class Shared_Counts_Front {
 			$link_class = ! empty( $link['class'] ) ? implode( ' ', array_map( 'sanitize_html_class' , explode( ' ', $link['class'] ) ) ) : '';
 			$target     = ! empty( $link['target'] ) ? ' target="' . esc_attr( $link['target'] ) . '" ' : '';
 			$rel        = ! empty( $link['rel'] ) ? ' rel="' . esc_attr( $link['rel'] ) . '" ' : '';
-			if( 'pinterest' == $type )
-				$rel .= ' data-pin-custom="true"';
-
 			$attr_title = ! empty( $link['attr_title'] ) ? ' title="' . esc_attr( $link['attr_title'] ) . '" ' : '';
 			$show_count = true;
 			$elements   = array();
@@ -587,6 +584,11 @@ class Shared_Counts_Front {
 			// Add classes.
 			if ( empty( $link['count'] ) || ( '1' === $options['total_only'] && 'included_total' !== $type ) ) {
 				$link['class'] .= ' shared-counts-no-count';
+			}
+
+			// Prevent Pinterest JS from hijacking our button.
+			if( 'pinterest' == $type ) {
+				$attr['pin-custom'] = 'true';
 			}
 
 			// Add data attribues.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: jaredatch, billerickson
 Tags: sharing, share buttons, social buttons, share counts, social, facebook, linkedin, pinterest, stumbleupon, twitter
 Requires at least: 4.6
-**Tested up to:** 4.9
-**Stable tag:** 1.1.0
-**License:** GPLv2 or later
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
+Tested up to: 4.9
+Stable tag: 1.1.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Shared Counts adds social sharing buttons that look great and keep your site loading fast.
 

--- a/readme.txt
+++ b/readme.txt
@@ -53,7 +53,7 @@ Contributions are welcome!
 2. Activate plugin.
 3. Go to Settings > Shared Counts to configure.
 
-We recommend you sign up for a free account at [SharedCounts.com](https://sharedcounts.com), which lets you receive share counts from all services (except Twitter) with a single API query. Alternatively, you can select "Native" as the count source and select which services you'd like to query. If you select all 5 native service queries, then you will have 5 separate API queries every time share counts are updated.
+We recommend you sign up for a free account at [SharedCount.com](https://sharedcount.com), which lets you receive share counts from all services (except Twitter) with a single API query. Alternatively, you can select "Native" as the count source and select which services you'd like to query. If you select all 5 native service queries, then you will have 5 separate API queries every time share counts are updated.
 
 If you would like to include Twitter share counts, you can sign up for a free account at [NewShareCounts.com](https://newsharecounts.com).
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ Additionally, Shared Counts was built to be developer friendly! We provide very 
 **Included Services**
 * Facebook
 * Pinterest
-* LinkedIn
+* Yummly
 * Twitter (using the third-party NewShareCounts.com API)
 * StumbleUpon
 * Email sharing (with reCAPTCHA support to prevent abuse)
@@ -74,4 +74,4 @@ If you use the Email share button, we recommend you enable Google's reCAPTCHA to
 - The minified stylesheet has been rebuilt. It was missing some styles.
 
 **Version 1.0.0**
-Initial release.
+- Initial release.

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,11 @@ Additionally, Shared Counts was built to be developer friendly! We provide very 
 
 * denotes button/service does not support share count tracking.
 
+**Add On Plugins**
+- [Shared Counts - Pinterest Image](https://github.com/billerickson/Shared-Counts-Pinterest-Image) - Upload a separate image for Pinterest sharing
+- [Shared Counts - Cache Status](https://github.com/billerickson/Shared-Counts-Cache-Status) - Build and check the status of the Shared Counts cache
+
+
 **Customization**
 For details on this please see [the wiki](https://github.com/jaredatch/Shared-Counts/wiki/).
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,8 @@ We include many styling options, and you can automatically insert the buttons be
 
 We provide a one-click option to retrieve both HTTP and HTTPS share counts, ensuring you don't lose your share counts when upgrading your website to HTTPS.
 
+**GDPR Compliant:** Unlike other social sharing tools, this plugin does not use cookies, tracking scripts, or store any user data. 
+
 Shared Counts was created with site performance in mind, even at large scale. It is used on several large websites that get tens of millions of page views each month. Our unique and creative caching methods have a minimal affect on site overhead. Leveraging the SharedCount.com API, we can retrieve (almost) all share counts in a single request.
 
 Additionally, Shared Counts was built to be developer friendly! We provide very liberal usage of hooks and filters. Everything is customizable and the possibilities are near limitless. Unlike other plugins all data (counts) are stored and cached in post_meta which makes it easy to access for extending (e.g. fetch top 10 most shared posts on your site).

--- a/readme.txt
+++ b/readme.txt
@@ -19,14 +19,19 @@ Shared Counts was created with site performance in mind, even at large scale. It
 
 Additionally, Shared Counts was built to be developer friendly! We provide very liberal usage of hooks and filters. Everything is customizable and the possibilities are near limitless. Unlike other plugins all data (counts) are stored and cached in post_meta which makes it easy to access for extending (e.g. fetch top 10 most shared posts on your site).
 
-**Included Services**
-* Facebook
-* Pinterest
-* Yummly
-* Twitter (using the third-party NewShareCounts.com API)
-* StumbleUpon
-* Email sharing (with reCAPTCHA support to prevent abuse)
-* Share count totals
+**Included Buttons**
+- Facebook
+- Pinterest
+- Yummly
+- Twitter (using the third-party NewShareCounts.com API)
+- StumbleUpon
+- Email sharing (with reCAPTCHA support to prevent abuse)
+- Share count totals
+- Print*
+- LinkedIn*
+- Google+*
+
+* denotes button/service does not support share count tracking.
 
 **Customization**
 For details on this please see [the wiki](https://github.com/jaredatch/Shared-Counts/wiki/).

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jaredatch, billerickson
 Tags: sharing, share buttons, social buttons, share counts, social, facebook, linkedin, pinterest, stumbleupon, twitter
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ If you use the Email share button, we recommend you enable Google's reCAPTCHA to
 1. Available styles
 
 == Changelog ==
+
+**Version 1.1.1**
+- Internal "prime the pump" method now includes all supported post types. Can be used with [this plugin](https://github.com/billerickson/Shared-Counts-Prime-Cache) to view the status of the cache and mass update posts.
+- Improved compatibility with Genesis theme framework.
 
 **Version 1.1.0**
 - Added Yummly share count support/tracking.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jaredatch, billerickson
 Tags: sharing, share buttons, social buttons, share counts, social, facebook, linkedin, pinterest, stumbleupon, twitter
 Requires at least: 4.6
 Tested up to: 4.9
-Stable tag: 1.1.1
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -15,7 +15,7 @@ We include many styling options, and you can automatically insert the buttons be
 
 We provide a one-click option to retrieve both HTTP and HTTPS share counts, ensuring you don't lose your share counts when upgrading your website to HTTPS.
 
-**GDPR Compliant:** Unlike other social sharing tools, this plugin does not use cookies, tracking scripts, or store any user data. 
+**GDPR Compliant:** Unlike other social sharing tools, this plugin does not use cookies, tracking scripts, or store any user data.
 
 Shared Counts was created with site performance in mind, even at large scale. It is used on several large websites that get tens of millions of page views each month. Our unique and creative caching methods have a minimal affect on site overhead. Leveraging the SharedCount.com API, we can retrieve (almost) all share counts in a single request.
 
@@ -71,6 +71,12 @@ If you use the Email share button, we recommend you enable Google's reCAPTCHA to
 1. Available styles
 
 == Changelog ==
+
+**Version 1.2.0**
+- Added support for [Pinterest Image](https://github.com/billerickson/Shared-Counts-Pinterest-Image) add-on plugin
+- "Hide empty counts" checkbox now works correctly
+- Pinterest "Pin it" JS no longer modifies our pinterest button
+- Metabox is now always visible, allowing you to disable share buttons even if not collecting counts
 
 **Version 1.1.1**
 - Internal "prime the pump" method now includes all supported post types. Can be used with [this plugin](https://github.com/billerickson/Shared-Counts-Prime-Cache) to view the status of the cache and mass update posts.

--- a/shared-counts.php
+++ b/shared-counts.php
@@ -4,7 +4,7 @@
  * Plugin URI:  https://wordpress.org/plugins/shared-counts/
  * Description: Social sharing buttons that look great and keep your site loading fast.
  * Author:      Bill Erickson & Jared Atchison
- * Version:     1.1.0
+ * Version:     1.1.1
  *
  * Shared Counts is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Basic plugin constants.
  */
 // Version.
-define( 'SHARED_COUNTS_VERSION', '1.1.0' );
+define( 'SHARED_COUNTS_VERSION', '1.1.1' );
 
 // Directory path.
 define( 'SHARED_COUNTS_DIR', plugin_dir_path( __FILE__ ) );

--- a/shared-counts.php
+++ b/shared-counts.php
@@ -4,7 +4,7 @@
  * Plugin URI:  https://wordpress.org/plugins/shared-counts/
  * Description: Social sharing buttons that look great and keep your site loading fast.
  * Author:      Bill Erickson & Jared Atchison
- * Version:     1.1.1
+ * Version:     1.2.0
  *
  * Shared Counts is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Basic plugin constants.
  */
 // Version.
-define( 'SHARED_COUNTS_VERSION', '1.1.1' );
+define( 'SHARED_COUNTS_VERSION', '1.2.0' );
 
 // Directory path.
 define( 'SHARED_COUNTS_DIR', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
## [1.2.0] = 2018-05-23
### Added
- Support for [Pinterest Image](https://github.com/billerickson/Shared-Counts-Pinterest-Image) add-on plugin

### Fixed
- "Hide empty counts" checkbox now works correctly
- Pinterest "Pin it" JS no longer modifies our pinterest button, see #34
- Metabox is now always visible, allowing you to disable share buttons even if not collecting counts, see #33
