### PR TITLE
Remove print javascript when AMP is enabled

### DIFF
--- a/includes/class-shared-counts-amp.php
+++ b/includes/class-shared-counts-amp.php
@@ -20,6 +20,7 @@ class Shared_Counts_AMP {
 	public function __construct() {
 		add_filter( 'shared_counts_load_js', array( $this, 'disable_js' ) );
 		add_filter( 'shared_counts_additional_attr', array( $this, 'print_action' ), 10, 4 );
+		add_filter( 'shared_counts_link', array( $this, 'print_link' ), 10, 3 );
 		add_filter( 'shared_counts_link', array( $this, 'email_action' ), 10, 3 );
 	}
 
@@ -63,6 +64,22 @@ class Shared_Counts_AMP {
 			$attr[] = 'on="tap:AMP.print()"';
 		}
 		return $attr;
+	}
+
+	/**
+	 * Remove print javascript.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array $link
+	 * @param int $id
+	 * @return array
+	 */
+	function print_link( $link, $id ) {
+		if( $this->is_amp() && 'print' === $link['type'] ) {
+			$link['link'] = '';
+		}
+		return $link;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->
<!--- You can link a corresponding issue. -->
With AMP enabled, javascript:window.print() was still showing on front end causing AMP not to be automatically validated. This removes the link if AMP is enabled.

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="894" alt="Screen Shot 2019-12-06 at 12 10 58 AM" src="https://user-images.githubusercontent.com/34251245/70301018-cab05400-17be-11ea-8d8e-c1e56371bf1b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project (WordPress coding standards, etc).
- [X] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [X] My code is tested for both new installs and for users that are upgrading from older versions.
