### PR TITLE
Fix native Facebook graph query to retrieve engagement counts

### DIFF
--- a/includes/class-shared-counts-core.php
+++ b/includes/class-shared-counts-core.php
@@ -630,6 +630,7 @@ class Shared_Counts_Core {
 						$token = shared_counts()->admin->settings_value( 'fb_access_token' );
 						if ( $token ) {
 							$args['access_token'] = rawurlencode( $token );
+							$args['fields'] = 'engagement';
 						}
 
 						$api_query = add_query_arg( $args, 'https://graph.facebook.com/' );
@@ -646,20 +647,13 @@ class Shared_Counts_Core {
 
 							$body = json_decode( wp_remote_retrieve_body( $api_response ) );
 
-							// Not sure why Facebook returns the data in different formats sometimes.
-							if ( isset( $body->shares ) && $body->shares > $share_count['Facebook']['share_count'] ) {
-								$share_count['Facebook']['share_count'] = $body->shares;
-							} elseif ( isset( $body->share->share_count ) && $body->share->share_count > $share_count['Facebook']['share_count'] ) {
-								$share_count['Facebook']['share_count'] = $body->share->share_count;
-							}
-							if ( isset( $body->comments ) && $body->comments > $share_count['Facebook']['comment_count'] ) {
-								$share_count['Facebook']['comment_count'] = $body->comments;
-							} elseif ( isset( $body->share->comment_count ) && $body->share->comment_count > $share_count['Facebook']['comment_count'] ) {
-								$share_count['Facebook']['comment_count'] = $body->share->comment_count;
+							if ( isset( $body->engagement ) ) {
+								$share_count['Facebook']['comment_count'] = $body->engagement->comment_count;
+								$share_count['Facebook']['share_count'] = $body->engagement->share_count;
+								$share_count['Facebook']['like_count'] = $body->engagement->reaction_count;
 							}
 
-							$share_count['Facebook']['like_count']  = $share_count['Facebook']['share_count'];
-							$share_count['Facebook']['total_count'] = $share_count['Facebook']['share_count'] + $share_count['Facebook']['comment_count'];
+							$share_count['Facebook']['total_count'] = $share_count['Facebook']['share_count'] + $share_count['Facebook']['comment_count'] + $share_count['Facebook']['like_count'];
 						}
 						break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I have added a new argument 'fields' to the Facebook api query to make it possible to retrieve count statistics again. Since the api response has changed, I have also updated the lines that assign the counts.

<!--- ## Testing procedure -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (WordPress coding standards, etc).
- [x] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [ ] My code is tested for both new installs and for users that are upgrading from older versions.
