### PR TITLE
Add share type parameter to shared_counts_link_url filter

### DIFF
--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -233,7 +233,7 @@ class Shared_Counts_Front {
 		if ( ! $this->share_link ) {
 			return;
 		}
-		
+
 		// Filter to disable email modal
 		if( apply_filters( 'shared_counts_disable_email_modal', false ) ) {
 			return;
@@ -499,7 +499,7 @@ class Shared_Counts_Front {
 				}
 				$link['img'] = apply_filters( 'shared_counts_single_image', $link['img'], $id, $link );
 			}
-			$link['url']   = apply_filters( 'shared_counts_link_url', $link['url'] );
+			$link['url']   = apply_filters( 'shared_counts_link_url', $link['url'], $link['type'] );
 			$link['count'] = shared_counts()->core->count( $id, $type, false, $round );
 
 			switch ( $type ) {

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -499,7 +499,7 @@ class Shared_Counts_Front {
 				}
 				$link['img'] = apply_filters( 'shared_counts_single_image', $link['img'], $id, $link );
 			}
-			$link['url']   = apply_filters( 'shared_counts_link_url', $link['url'], $link['type'] );
+			$link['url']   = apply_filters( 'shared_counts_link_url', $link['url'], $link );
 			$link['count'] = shared_counts()->core->count( $id, $type, false, $round );
 
 			switch ( $type ) {


### PR DESCRIPTION
Adding a second parameter to the `shared_counts_link_url` filter.

## Description
Adding a second parameter to the filter allows users to check for the type of share, and change the share link accordingly. Solves issue #105 

## Testing procedure
1. In a development environment, used the `shared_counts_link_url` filter as it currently stands 
2. Added a second parameter to the `shared_counts_link_url` filter
3. Checks that using the filter as it currently constructed still works
4. Added 2 as the $acceptable_args when calling the `shared_counts_link_url` filter.
5. Able to test against the parameter passed in

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
[ ] Bug fix (non-breaking change which fixes an issue)
[x] Enhancement (modification of the currently available functionality)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
[x] My code follows the code style of this project (WordPress coding standards, etc).
[x] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
[x] My code is tested for both new installs and for users that are upgrading from older versions.
