### PR TITLE
Fixes #107: Correct the facebook likes, comment and shares count.

### DIFF
--- a/includes/class-shared-counts-core.php
+++ b/includes/class-shared-counts-core.php
@@ -475,7 +475,7 @@ class Shared_Counts_Core {
 			$results = json_decode( wp_remote_retrieve_body( $api_response ), true );
 
 			// Update counts.
-			$share_count['Facebook']['like_count']    = isset( $results['Facebook']['like_count'] ) && $results['Facebook']['like_count'] > $share_count['Facebook']['like_count'] ? $results['Facebook']['like_count'] : $share_count['Facebook']['like_count'];
+			$share_count['Facebook']['like_count']    = isset( $results['Facebook']['reaction_count'] ) && $results['Facebook']['reaction_count'] > $share_count['Facebook']['like_count'] ? $results['Facebook']['reaction_count'] : $share_count['Facebook']['like_count'];
 			$share_count['Facebook']['comment_count'] = isset( $results['Facebook']['comment_count'] ) && $results['Facebook']['comment_count'] > $share_count['Facebook']['comment_count'] ? $results['Facebook']['comment_count'] : $share_count['Facebook']['comment_count'];
 			$share_count['Facebook']['share_count']   = isset( $results['Facebook']['share_count'] ) && $results['Facebook']['share_count'] > $share_count['Facebook']['share_count'] ? $results['Facebook']['share_count'] : $share_count['Facebook']['share_count'];
 			$share_count['Facebook']['total_count']   = isset( $results['Facebook']['total_count'] ) && $results['Facebook']['total_count'] > $share_count['Facebook']['total_count'] ? $results['Facebook']['total_count'] : $share_count['Facebook']['total_count'];

--- a/includes/class-shared-counts-core.php
+++ b/includes/class-shared-counts-core.php
@@ -209,13 +209,13 @@ class Shared_Counts_Core {
 					$share_count = isset( $counts['Facebook']['total_count'] ) ? $counts['Facebook']['total_count'] : '0';
 					break;
 				case 'facebook_likes':
-					$share_count = isset( $counts['like_count'] ) ? $counts['like_count'] : '0';
+					$share_count = isset( $counts['Facebook']['like_count'] ) ? $counts['Facebook']['like_count'] : '0';
 					break;
 				case 'facebook_shares':
-					$share_count = isset( $counts['share_count'] ) ? $counts['share_count'] : '0';
+					$share_count = isset( $counts['Facebook']['share_count'] ) ? $counts['Facebook']['share_count'] : '0';
 					break;
 				case 'facebook_comments':
-					$share_count = isset( $counts['comment_count'] ) ? $counts['comment_count'] : '0';
+					$share_count = isset( $counts['Facebook']['comment_count'] ) ? $counts['Facebook']['comment_count'] : '0';
 					break;
 				case 'twitter':
 					$share_count = isset( $counts['Twitter'] ) ? $counts['Twitter'] : '0';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Facebook share, comment and like count wasn't correctly retrieved in `Shared_Counts_Core->count()`.
Instead of retrieving them from `$counts['Facebook']`, they where retrieved from `$counts` where they didn't exist.

Also where the api result is retrieved (`Shared_Counts_Core->query_sharedcount_api()`) the like_count wasn't correctly retrieved, since it is called "reaction_count" there instead of 'like_count'. So now the correct Facebook Likes count is retrieved and shown.

What I didn't fix is that the number presented by adding the total counts service counts facebook shares and facebook likes double when they are added as service in combination with the general facebook service. 

The latter already contains the sum of likes, shares and comments and adding the fb likes an fb shares service will again add those counts to the total making the end result the correct sum of all the services, but it doesn't reflect the correct number of social interactions. 

So it might be more correct to only count them once, although in practice it might not be a problem when most users just add one or the other.

<!--- You can link a corresponding issue. -->
#107 

## Testing procedure
The retrieval of the likes count from the api, I tested in admin, by opening a post in the editor that had all types of Facebook counts and checking if all numbers where there and if the sum adds up.
I also var_dumped the count arrays and results at one point, mainly to check how the total was build.
The count on the frontend I just tested by adding and removing services in the settings and seeing the result.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project (WordPress coding standards, etc).
- [ ] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [ ] My code is tested for both new installs and for users that are upgrading from older versions.
