### PR TITLE
Auto fill logged in user email and name

### DIFF
--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -269,12 +269,16 @@ class Shared_Counts_Front {
 			]
 		);
 
+		// Get currently logged in user if applicable.
 		$user = get_userdata( get_current_user_id() );
 
-		$user_first_name   = $user->first_name;
-		$user_last_name    = $user->last_name;
-		$user_display_name = $user->display_name;
-		$user_name         = ! empty( $user_display_name ) ? $user_display_name : $user_first_name . ' ' . $user_last_name;
+		// Get the name parts.
+		$user_first_name   = ! empty( $user ) ? $user->first_name : '';
+		$user_last_name    = ! empty( $user ) ? $user->last_name : '';
+		$user_display_name = ! empty( $user ) ? $user->display_name : '';
+
+		// If display name is empty use the first and last name.
+		$user_name = ! empty( $user_display_name ) ? $user_display_name : $user_first_name . ' ' . $user_last_name;
 		?>
 		<div id="shared-counts-modal-wrap" style="display:none;">
 			<div class="shared-counts-modal">

--- a/includes/class-shared-counts-front.php
+++ b/includes/class-shared-counts-front.php
@@ -268,6 +268,13 @@ class Shared_Counts_Front {
 				'submit'     => esc_html__( 'Send Email', 'shared-counts' ),
 			]
 		);
+
+		$user = get_userdata( get_current_user_id() );
+
+		$user_first_name   = $user->first_name;
+		$user_last_name    = $user->last_name;
+		$user_display_name = $user->display_name;
+		$user_name         = ! empty( $user_display_name ) ? $user_display_name : $user_first_name . ' ' . $user_last_name;
 		?>
 		<div id="shared-counts-modal-wrap" style="display:none;">
 			<div class="shared-counts-modal">
@@ -286,18 +293,19 @@ class Shared_Counts_Front {
 					?>
 				</div>
 				<div class="shared-counts-modal-content">
-					<p>
-						<label for="shared-counts-modal-recipient"><?php echo esc_html( $labels['recipient'] ); ?></label>
-						<input type="email" id="shared-counts-modal-recipient" placeholder="<?php echo esc_html( $labels['recipient'] ); ?>">
-					</p>
-					<p>
-						<label for="shared-counts-modal-name"><?php echo esc_html( $labels['name'] ); ?></label>
-						<input type="text" id="shared-counts-modal-name" placeholder="<?php echo esc_html( $labels['name'] ); ?>">
-					</p>
-					<p>
-						<label for="shared-counts-modal-email"><?php echo esc_html( $labels['email'] ); ?></label>
-						<input type="email" id="shared-counts-modal-email" placeholder="<?php echo esc_html( $labels['email'] ); ?>">
-					</p>
+					<?php if ( is_user_logged_in() ) : ?>
+						<input type="hidden" id="shared-counts-modal-name" value="<?php echo esc_attr( $user_name ); ?>">
+						<input type="hidden" id="shared-counts-modal-email" value="<?php echo esc_attr( $user->user_email ); ?>">
+					<?php else : ?>
+						<p>
+							<label for="shared-counts-modal-name"><?php echo esc_html( $labels['name'] ); ?></label>
+							<input type="text" id="shared-counts-modal-name" placeholder="<?php echo esc_html( $labels['name'] ); ?>">
+						</p>
+						<p>
+							<label for="shared-counts-modal-email"><?php echo esc_html( $labels['email'] ); ?></label>
+							<input type="email" id="shared-counts-modal-email" placeholder="<?php echo esc_html( $labels['email'] ); ?>">
+						</p>
+					<?php endif; ?>
 					<?php
 					if ( $recaptcha ) {
 						echo '<div id="shared-counts-modal-recaptcha"></div>';


### PR DESCRIPTION
Added functionality to auto fill logged in user's name and email for the email form.

## Description
Get the user details and if the user passes the logged in check the name and email fields will be rendred as hidden and the values for those fields will be automatically populated.

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (WordPress coding standards, etc).
- [x] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [ ] My code is tested for both new installs and for users that are upgrading from older versions.
