### PR TITLE
Issue/137 - Add support to install via Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 build/
 release.sh
 .DS_Store
+Vendor/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Shared Counts](https://sharedcountsplugin.com/) #
+# [Shared Counts](https://sharedcountsplugin.com/) 
 
 ![Plugin Version](https://img.shields.io/wordpress/plugin/v/shared-counts.svg?style=flat-square) ![Total Downloads](https://img.shields.io/wordpress/plugin/dt/shared-counts.svg?style=flat-square) ![Plugin Rating](https://img.shields.io/wordpress/plugin/r/shared-counts.svg?style=flat-square) ![WordPress Compatibility](https://img.shields.io/wordpress/v/shared-counts.svg?style=flat-square) ![License](https://img.shields.io/badge/license-GPL--2.0%2B-red.svg?style=flat-square)
 
@@ -88,7 +88,7 @@ Contributions are welcome!
 4. When committing, reference your issue and provide notes/feedback.
 5. Send us a Pull Request with your bug fixes and/or new features.
 
-## Installation ##
+## Installation
 1. Download the plugin [from GitHub.](https://github.com/jaredatch/Shared-Counts/archive/master.zip) or from [WordPress.org](https://wordpress.org/plugins/shared-counts/).
 2. Activate plugin.
 3. Go to Settings > Shared Counts to configure.
@@ -99,5 +99,25 @@ If you would like to include Twitter share counts, you can sign up for a free ac
 
 If you use the Email share button, we recommend you enable Google's reCAPTCHA to prevent spam. [Sign up here](https://www.google.com/recaptcha/intro/android.html) (free) to get your Site Key and Secret Key.
 
-## This Repo ##
+### Installing via Composer
+
+Add the package to your `composer.json` file:
+
+```
+{
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/jaredatch/Shared-Counts.git"
+    }
+  ],
+  "require": {
+    "jaredatch/shared-counts": "*"
+  }
+}
+```
+
+And run `composer update`.
+
+## This Repo
 Master branch is always stable and contains latest releases. Development occurs in the develop branch while large features/changes are contained in dedicated branches. For reporting bugs or contributing, see more additional information below.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "jaredatch/shared-counts",
+    "description": "WordPress plugin that leverages SharedCount.com API to quickly retrieve, cache, and display various social sharing counts.",
+    "type": "wordpress-plugin",
+    "license": "GPLv2+",
+    "authors": [
+        {
+            "name": "Jared Atchison",
+            "homepage": "http://www.jaredatchison.com/"
+        },
+        {
+            "name": "Bill Erickson",
+            "homepage": "http://www.billerickson.net/"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
Adding support to install this plugin from the github repo as a composer package.

## Description

Noted in #137, this adds a `composer.json` file to correctly mark the github repo as a `wordpress-plugin` and be installable from the repo by Composer.

## Testing procedure

It will install with composer using the `issue/137` branch on my forked repo using:

```
{
  "repositories": [
    {
      "type": "git",
      "url": "https://github.com/joshuadavidnelson/Shared-Counts.git"
    }
  ],
  "require": {
    "jaredatch/shared-counts": "dev-issue/137"
  }
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (WordPress coding standards, etc).
- [ ] ~~My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.~~
- [ ] ~~My code is tested for both new installs and for users that are upgrading from older versions.~~
